### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=Stefano
 maintainer=Stefano <stefano.pulze87@gmail.com>
 sentence=Led library
 paragraph=Led library
-category=Led
+category=Device Control
 url=https://github.com/stefanopulze/led
 architectures=*


### PR DESCRIPTION
The previous category value caused the warning:
```
WARNING: Category 'Led' in library Led library is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format